### PR TITLE
Use assert instead of return bool

### DIFF
--- a/curdleproofs/curdleproofs/curdleproofs.py
+++ b/curdleproofs/curdleproofs/curdleproofs.py
@@ -87,7 +87,7 @@ class CurdleProofsProof:
             compute_MSM(crs.vec_H, vec_r_a_prime),
         )
 
-        (same_perm_proof, err) = SamePermutationProof.new(
+        same_perm_proof = SamePermutationProof.new(
             crs_G_vec=crs.vec_G,
             crs_H_vec=crs.vec_H,
             crs_U=crs.H,
@@ -99,9 +99,6 @@ class CurdleProofsProof:
             vec_m_blinders=vec_m_blinders,
             transcript=transcript,
         )
-
-        if same_perm_proof is None:
-            raise Exception(err)
 
         r_t = Fr(random.randint(1, Fr.field_modulus))
         r_u = Fr(random.randint(1, Fr.field_modulus))
@@ -181,14 +178,14 @@ class CurdleProofsProof:
         vec_T: List[PointProjective],
         vec_U: List[PointProjective],
         M: PointProjective,
-    ) -> Tuple[bool, str]:
+    ):
         ell = len(vec_R)
 
         transcript = CurdleproofsTranscript(b"curdleproofs")
         msm_accumulator = MSMAccumulator()
 
         if is_inf(vec_T[0]):
-            return False, "vec_T[0] is infinity"
+            raise Exception("vec_T[0] is infinity")
 
         transcript.append_list(
             b"curdleproofs_step1", points_projective_to_bytes(vec_R + vec_S + vec_T + vec_U)
@@ -259,12 +256,7 @@ class CurdleProofsProof:
             self.S, vec_S, vec_a
         )
 
-        msm_verify = msm_accumulator.verify()
-
-        if not msm_verify:
-            return False, "MSM check failed"
-
-        return True, ""
+        msm_accumulator.verify()
 
     def to_json(self):
         return {

--- a/curdleproofs/curdleproofs/grand_prod.py
+++ b/curdleproofs/curdleproofs/grand_prod.py
@@ -11,7 +11,7 @@ from curdleproofs.util import (
     fr_to_bytes,
 )
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
-from typing import List, Optional, Tuple, TypeVar, Type
+from typing import List, TypeVar, Type
 from curdleproofs.util import (
     PointProjective,
     Fr,
@@ -45,7 +45,7 @@ class GrandProductProof:
         vec_b: List[Fr],
         vec_b_blinders: List[Fr],
         transcript: CurdleproofsTranscript,
-    ) -> Tuple[Optional[T_GrandProductProof], Optional[str]]:
+    ) -> T_GrandProductProof:
         n_blinders = len(vec_b_blinders)
         ell = len(crs_G_vec)
 
@@ -115,7 +115,7 @@ class GrandProductProof:
         assert eq(compute_MSM(vec_G, vec_c), C)
         assert eq(compute_MSM(vec_G_prime, vec_d), D)
 
-        (ipa_proof, err) = IPA.new(
+        ipa_proof = IPA.new(
             crs_G_vec=vec_G,
             crs_G_prime_vec=vec_G_prime,
             crs_H=crs_U,
@@ -127,10 +127,7 @@ class GrandProductProof:
             transcript=transcript,
         )
 
-        if ipa_proof is None:
-            return None, err
-
-        return cls(C, r_p, ipa_proof), None
+        return cls(C, r_p, ipa_proof)
 
     def verify(
         self,
@@ -144,7 +141,7 @@ class GrandProductProof:
         n_blinders: int,
         transcript: CurdleproofsTranscript,
         msm_accumulator: MSMAccumulator,
-    ) -> Tuple[bool, str]:
+    ):
         ell = len(crs_G_vec)
 
         # Step 1
@@ -182,7 +179,7 @@ class GrandProductProof:
             self.r_p * (beta ** (ell + 1)) + gprod_result * (beta**ell) - Fr.one()
         )
 
-        (ipa_result, err) = self.ipa_proof.verify(
+        self.ipa_proof.verify(
             crs_G_vec=vec_G,
             crs_H=crs_U,
             C=self.C,
@@ -192,11 +189,6 @@ class GrandProductProof:
             transcript=transcript,
             msm_accumulator=msm_accumulator,
         )
-
-        if not ipa_result:
-            return False, err
-
-        return True, ""
 
     def to_json(self):
         return {

--- a/curdleproofs/curdleproofs/ipa.py
+++ b/curdleproofs/curdleproofs/ipa.py
@@ -12,7 +12,7 @@ from curdleproofs.util import (
     log2_int,
 )
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
-from typing import List, Optional, Tuple, Type, TypeVar
+from typing import List, Tuple, Type, TypeVar
 from curdleproofs.util import (
     PointProjective,
     Fr,
@@ -89,13 +89,13 @@ class IPA:
         vec_c: List[Fr],
         vec_d: List[Fr],
         transcript: CurdleproofsTranscript,
-    ) -> Tuple[Optional[T_IPA], Optional[str]]:
+    ) -> T_IPA:
         n = len(vec_c)
         lg_n = int(log2(n))
         if n != 2**lg_n:
-            return (None, "n != 2 ** lg_n, not a power of 2")
+            raise Exception("n != 2 ** lg_n, not a power of 2")
         if n != len(vec_d):
-            return (None, "len(vec_c) != len(vec_d)")
+            raise Exception("len(vec_c) != len(vec_d)")
 
         (vec_r_c, vec_r_d) = generate_ipa_blinders(vec_c, vec_d)
 
@@ -155,19 +155,16 @@ class IPA:
             crs_G_vec = G_L
             crs_G_prime_vec = G_prime_L
 
-        return (
-            cls(B_c, B_d, vec_L_C, vec_R_C, vec_L_D, vec_R_D, vec_c[0], vec_d[0]),
-            None,
-        )
+        return cls(B_c, B_d, vec_L_C, vec_R_C, vec_L_D, vec_R_D, vec_c[0], vec_d[0])
 
     def verification_scalars(
         self, n: int, transcript: CurdleproofsTranscript
-    ) -> Tuple[Tuple[List[Fr], List[Fr], List[Fr], List[Fr]], Optional[str]]:
+    ) -> Tuple[List[Fr], List[Fr], List[Fr], List[Fr]]:
         lg_n = len(self.vec_L_C)
         if lg_n >= 32:
-            return (([], [], [], []), "vec_L_C too large")
+            raise Exception("vec_L_C too large")
         elif n != 2**lg_n:
-            return (([], [], [], []), "n != 2 ** lg_n")
+            raise Exception("n != 2 ** lg_n")
 
         verification_scalars_bitstring = get_verification_scalars_bitstring(n, lg_n)
 
@@ -191,7 +188,7 @@ class IPA:
 
         vec_s_inv = [invert(s) for s in vec_s]
 
-        return ((challenges, challenges_inv, vec_s, vec_s_inv), None)
+        return (challenges, challenges_inv, vec_s, vec_s_inv)
 
     def verify(
         self,
@@ -203,7 +200,7 @@ class IPA:
         vec_u: List[Fr],
         transcript: CurdleproofsTranscript,
         msm_accumulator: MSMAccumulator,
-    ) -> Tuple[bool, str]:
+    ):
         n = len(crs_G_vec)
         # assert(((n != 0) and (n & (n-1) == 0)), "n must be a power of 2")
 
@@ -217,11 +214,9 @@ class IPA:
         alpha = transcript.get_and_append_challenge(b"ipa_alpha")
         beta = transcript.get_and_append_challenge(b"ipa_beta")
 
-        ((vec_gamma, vec_gamma_inv, vec_s, vec_s_inv), err) = self.verification_scalars(
+        (vec_gamma, vec_gamma_inv, vec_s, vec_s_inv) = self.verification_scalars(
             n, transcript
         )
-        if err is not None:
-            return (False, err)
 
         vec_c_times_s = [self.c_final * s for s in vec_s]
         vec_rhs_scalars = vec_c_times_s + [self.c_final * self.d_final * beta]
@@ -250,8 +245,6 @@ class IPA:
             compute_MSM(self.vec_R_D, vec_gamma_inv),
         )
         msm_accumulator.accumulate_check(point_lhs, crs_G_vec, vec_d_div_s)
-
-        return (True, "")
 
     def to_json(self):
         return {

--- a/curdleproofs/curdleproofs/msm_accumulator.py
+++ b/curdleproofs/curdleproofs/msm_accumulator.py
@@ -66,7 +66,7 @@ class MSMAccumulator:
                 base_affine_int
             ] + random_factor * Fr(scalar)
 
-    def verify(self) -> bool:
+    def verify(self):
         bases: List[Tuple[int, int]]
         scalars: List[Fr]
         bases, scalars = map(list, zip(*self.base_scalar_map.items()))  # type: ignore
@@ -75,4 +75,4 @@ class MSMAccumulator:
             list(map(int, scalars)),
         )
         # print("bases", bases, "scalars", scalars, "computed", normalize(computed), "expected", normalize(self.A_c), "eq", eq(computed, self.A_c))
-        return eq(computed, self.A_c)
+        assert eq(computed, self.A_c)

--- a/curdleproofs/curdleproofs/opening.py
+++ b/curdleproofs/curdleproofs/opening.py
@@ -67,7 +67,7 @@ class TrackerOpeningProof:
         k_r_G: PointProjective,
         r_G: PointProjective,
         k_G: PointProjective,
-    ) -> bool:
+    ):
         transcript.append_list(
             b"tracker_opening_proof",
             points_projective_to_bytes([k_G, G1, k_r_G, r_G, self.A, self.B]),
@@ -79,7 +79,7 @@ class TrackerOpeningProof:
         Aprime = add(multiply(G1, int(self.s)), multiply(k_G, int(challenge)))
         Bprime = add(multiply(r_G, int(self.s)), multiply(k_r_G, int(challenge)))
 
-        return eq(Aprime, self.A) and eq(Bprime, self.B)
+        assert eq(Aprime, self.A) and eq(Bprime, self.B)
 
     def to_json(self):
         return {

--- a/curdleproofs/curdleproofs/same_perm.py
+++ b/curdleproofs/curdleproofs/same_perm.py
@@ -1,7 +1,7 @@
 from functools import reduce
 from curdleproofs.grand_prod import GrandProductProof
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
-from typing import List, Optional, Tuple, Type, TypeVar
+from typing import List, Type, TypeVar
 from curdleproofs.util import (
     PointProjective,
     Fr,
@@ -42,7 +42,7 @@ class SamePermutationProof:
         vec_a_blinders: List[Fr],
         vec_m_blinders: List[Fr],
         transcript: CurdleproofsTranscript,
-    ) -> Tuple[Optional[T_SAME_PERM_PROOF], str]:
+    ) -> T_SAME_PERM_PROOF:
         n_blinders = len(vec_a_blinders)
         ell = len(crs_G_vec)
 
@@ -66,7 +66,7 @@ class SamePermutationProof:
             vec_a_blinders[i] + alpha * vec_m_blinders[i] for i in range(0, n_blinders)
         ]
 
-        (grand_product_proof, err) = GrandProductProof.new(
+        grand_product_proof = GrandProductProof.new(
             crs_G_vec=crs_G_vec,
             crs_H_vec=crs_H_vec,
             crs_U=crs_U,
@@ -77,10 +77,7 @@ class SamePermutationProof:
             transcript=transcript,
         )
 
-        if grand_product_proof is None:
-            return (None, err or "")
-
-        return cls(B, grand_product_proof), ""
+        return cls(B, grand_product_proof)
 
     def verify(
         self,
@@ -95,7 +92,7 @@ class SamePermutationProof:
         n_blinders: int,
         transcript: CurdleproofsTranscript,
         msm_accumulator: MSMAccumulator,
-    ) -> Tuple[bool, str]:
+    ):
         ell = len(crs_G_vec)
 
         # Step 1
@@ -117,7 +114,7 @@ class SamePermutationProof:
             vec_beta_repeated,
         )
 
-        (grand_prod_verify, err) = self.grand_prod_proof.verify(
+        self.grand_prod_proof.verify(
             crs_G_vec=crs_G_vec,
             crs_H_vec=crs_H_vec,
             crs_U=crs_U,
@@ -129,11 +126,6 @@ class SamePermutationProof:
             transcript=transcript,
             msm_accumulator=msm_accumulator,
         )
-
-        if not grand_prod_verify:
-            return (False, err)
-
-        return (True, "")
 
     def to_json(self):
         return {

--- a/curdleproofs/curdleproofs/same_scalar.py
+++ b/curdleproofs/curdleproofs/same_scalar.py
@@ -2,7 +2,7 @@ import random
 from curdleproofs.commitment import GroupCommitment
 from curdleproofs.util import field_from_json, field_to_json, points_projective_to_bytes
 from curdleproofs.curdleproofs_transcript import CurdleproofsTranscript
-from typing import Tuple, Type, TypeVar
+from typing import Type, TypeVar
 from curdleproofs.util import (
     PointProjective,
     Fr,
@@ -81,7 +81,7 @@ class SameScalarProof:
         cm_T: GroupCommitment,
         cm_U: GroupCommitment,
         transcript: CurdleproofsTranscript,
-    ) -> Tuple[bool, str]:
+    ):
         transcript.append_list(
             b"sameexp_points",
             points_projective_to_bytes(
@@ -111,10 +111,7 @@ class SameScalarProof:
         computed_1 = self.cm_A + (cm_T * alpha)
         computed_2 = self.cm_B + (cm_U * alpha)
 
-        if expected_1 == computed_1 and expected_2 == computed_2:
-            return (True, "")
-        else:
-            return (False, "Failure")
+        assert expected_1 == computed_1 and expected_2 == computed_2
 
     def to_json(self):
         return {

--- a/curdleproofs/curdleproofs/whisk_interface.py
+++ b/curdleproofs/curdleproofs/whisk_interface.py
@@ -75,7 +75,7 @@ def IsValidWhiskShuffleProof(
     pre_shuffle_trackers: Sequence[WhiskTracker],
     post_shuffle_trackers: Sequence[WhiskTracker],
     whisk_shuffle_proof_bytes: WhiskShuffleProofBytes,
-) -> Tuple[bool, str]:
+):
     """
     Verify `post_shuffle_trackers` is a permutation of `pre_shuffle_trackers`.
     """


### PR DESCRIPTION
API style of return Tuple[T, str] mimics Rust. However it mixes this API with exception raising. Given python is a exception based language best to use exception consistently for easier reasoning

Closes https://github.com/nalinbhardwaj/curdleproofs.pie/issues/16

- Repeat PR as https://github.com/nalinbhardwaj/curdleproofs.pie/pull/18 merged to stale branch
