### PR TITLE
Set py_arkworks version to ^0.3.5

### DIFF
--- a/curdleproofs/poetry.lock
+++ b/curdleproofs/poetry.lock
@@ -369,4 +369,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3361e8d845be37d4d74aed8e2f86c17d4f16b7f05a5d024499513bec9514cfcc"
+content-hash = "1240cc6757a0456a70fd5c356bab9781215bdabd5cbe8deb70d60d2c9121898b"

--- a/curdleproofs/pyproject.toml
+++ b/curdleproofs/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-py_arkworks_bls12381 = "0.3.5"
+py_arkworks_bls12381 = "^0.3.5"
 merlin_transcripts = "0.1.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Related to #25. To prevent future conflicts with consensus-specs, we can change the version to allow v0 updates.